### PR TITLE
Fix Null case in byte_stream constructor.

### DIFF
--- a/byte_stream.h
+++ b/byte_stream.h
@@ -50,11 +50,19 @@ public :
    /// constructor
    byte_stream (const char * cp_in)
    {
-      u_length = strlen (cp_in) + 1;
-      bp_in = new _byte_ [u_length] ;
-      memcpy (bp_in, cp_in, u_length);
-      bp_current = bp_in;
-      bp_end = bp_in + u_length - 1;
+      if(cp_in)
+      {
+         u_length = strlen (cp_in) + 1;
+         bp_in = new _byte_ [u_length] ;
+         memcpy (bp_in, cp_in, u_length);
+         bp_current = bp_in;
+         bp_end = bp_in + u_length - 1;
+      }
+      else
+      {
+         u_length = 0;
+         bp_in = bp_current = bp_end = 0;
+      }
       o_valid = (bp_current != bp_end);
    }
    /// destructor


### PR DESCRIPTION
E.g:
xpath_processor::xpath_processor (
   const TiXmlNode \* XNp_source_tree,  ///< Source XML tree
   const char \* cp_xpath_expr)         ///< XPath expression
      : xpath_stream (cp_xpath_expr)

While calling xpath_stream if cp_xpath_expr is NULL, then it will call byte_stream constructor which will crash in below line:
u_length = strlen (cp_in) + 1;  // strlen(NULL) crashes the code.
So, Null handling done in byte_Stream.
